### PR TITLE
rename function avoid name conflict with htslib

### DIFF
--- a/include/phast_misc.h
+++ b/include/phast_misc.h
@@ -753,7 +753,7 @@ double get_elapsed_time(struct timeval *start_time);
   @param filename path of file to check for
   @result 1 if exists and readable
 */
-int file_exists(char *filename);
+int phast_file_exists(char *filename);
 
 
 /** \name IUPAC mapping functions

--- a/src/lib/base/phast_misc.c
+++ b/src/lib/base/phast_misc.c
@@ -1103,8 +1103,9 @@ double get_elapsed_time(struct timeval *start_time) {
     (now.tv_usec - start_time->tv_usec)/1.0e6;
 }
 
-/* check to see if a file is present and readable on the filesystem */
-int file_exists(char *filename) {
+/* check to see if a file is present and readable on the filesystem.
+ * phast_ prefix added due to conflicts with htslib */
+int phast_file_exists(char *filename) {
  return (access(filename, F_OK) == 0);
 }
 


### PR DESCRIPTION
Rename file_exists to phast_file_exists to avoid name conflict with htslib.  This causes HAL to be unable to link with both phast and phylop.

Note that file_exists is not used.