### PR TITLE
fixed compile errors due to name changes

### DIFF
--- a/src/dless/Makefile
+++ b/src/dless/Makefile
@@ -3,7 +3,7 @@ PHAST := ${PHAST}/..
 
 #EXEC = $(addprefix ${BIN}/,$(notdir ${PWD}))
 PROGS = dless dlessP
-MODULES = bd_phylo_hmm
+MODULES = phast_bd_phylo_hmm
 EXEC = $(addprefix ${BIN}/,${PROGS})
 
 # assume all *.c files are source

--- a/src/prequel/Makefile
+++ b/src/prequel/Makefile
@@ -3,7 +3,7 @@ PHAST := ${PHAST}/..
 
 # assume executable name is given by directory name
 PROGS = pbsDecode pbsEncode pbsScoreMatrix pbsTrain prequel
-MODULES = simplex_grid pbs_code
+MODULES = phast_simplex_grid phast_pbs_code
 EXEC = $(addprefix ${BIN}/,${PROGS})
 
 # assume all *.c files are source


### PR DESCRIPTION
A couple of programs didn't compile because of source file name changes.  This fixes the Makefiles to use the new names.