### PR TITLE
force sequential access to libphast.a during compilation

### DIFF
--- a/src/lib/base/Makefile
+++ b/src/lib/base/Makefile
@@ -17,3 +17,5 @@ ${TARGETLIB}(${OBJS}) : ${OBJS}
 
 clean:
 	rm -f *.o 
+
+.NOTPARALLEL:

--- a/src/lib/feature/Makefile
+++ b/src/lib/feature/Makefile
@@ -17,3 +17,5 @@ ${TARGETLIB}(${OBJS}) : ${OBJS}
 
 clean:
 	rm -f *.o 
+
+.NOTPARALLEL:

--- a/src/lib/hmm/Makefile
+++ b/src/lib/hmm/Makefile
@@ -17,3 +17,5 @@ ${TARGETLIB}(${OBJS}) : ${OBJS}
 
 clean:
 	rm -f *.o 
+
+.NOTPARALLEL:

--- a/src/lib/motif/Makefile
+++ b/src/lib/motif/Makefile
@@ -17,3 +17,5 @@ ${TARGETLIB}(${OBJS}) : ${OBJS}
 
 clean:
 	rm -f *.o 
+
+.NOTPARALLEL:

--- a/src/lib/msa/Makefile
+++ b/src/lib/msa/Makefile
@@ -17,3 +17,5 @@ ${TARGETLIB}(${OBJS}) : ${OBJS}
 
 clean:
 	rm -f *.o 
+
+.NOTPARALLEL:

--- a/src/lib/phylo/Makefile
+++ b/src/lib/phylo/Makefile
@@ -17,3 +17,5 @@ ${TARGETLIB}(${OBJS}) : ${OBJS}
 
 clean:
 	rm -f *.o 
+
+.NOTPARALLEL:

--- a/src/lib/phylo_hmm/Makefile
+++ b/src/lib/phylo_hmm/Makefile
@@ -17,3 +17,5 @@ ${TARGETLIB}(${OBJS}) : ${OBJS}
 
 clean:
 	rm -f *.o 
+
+.NOTPARALLEL:

--- a/src/lib/rphast/Makefile
+++ b/src/lib/rphast/Makefile
@@ -14,3 +14,5 @@ ${TARGETLIB}(${OBJS}) : ${OBJS}
 
 clean:
 	rm -f *.o 
+
+.NOTPARALLEL:


### PR DESCRIPTION
When building phast using make's parallel capabilities, the build almost always fails because the many subdirectories of src/lib/*/ are trying to add objects to the libphast.a static library at the same time, resulting in corruption and weird error messages like:

	gcc  -L/<<PKGBUILDDIR>>/src/dless/../../lib  -o /<<PKGBUILDDIR>>/src/dless/../../bin/dless dless.o phast_bd_phylo_hmm.o -lphast -llapack -ltmglib -lblas -lc -lm -lpcre2-8 -Wl,-z,relro -Wl,-z,now
	/usr/bin/ld: /<<PKGBUILDDIR>>/src/dless/../../lib/libphast.a: error adding symbols: malformed archive
	collect2: error: ld returned 1 exit status

Placing .NOTPARALLEL pseudo targets at strategic locations looks to reliably resolve the problem while preserving otherwise some level of parallelism where the library is not involved.  Checkout the GNU Make manual's chapter about [Disabling Parallel Execution] for further details.

This issue has been initially reported as [Debian bug #1091563]; the original title is misleading as the problem has initially been caught during a build campaign on i386 after introduction of the latest version of GNU Make 4.4, which introduced a rehaul of the job parallelism system.

[Disabling Parallel Execution]: https://www.gnu.org/software/make/manual/html_node/Parallel-Disable.html
[Debian bug #1091563]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1091563