### PR TITLE
maf_parse: Allow maf blocks with duplicate srcNames.

### DIFF
--- a/src/lib/msa/phast_maf_block.c
+++ b/src/lib/msa/phast_maf_block.c
@@ -289,9 +289,6 @@ MafBlock *mafBlock_read_next(FILE *mfile, Hashtable *specHash, int *numSpec) {
     //if 's' or 'e', then this is first line of data for this species
     else if (firstchar == 's' || firstchar == 'e') {
       sub = mafBlock_get_subBlock(currLine);
-      if (hsh_get_int(block->specMap, sub->src->chars) != -1) 
-	die("ERROR: mafBlock has two alignments with same srcName (%s)\n", 
-	    sub->src->chars);
       hsh_put_int(block->specMap, sub->src->chars, lst_size(block->data));
       hsh_put_int(block->specMap, sub->specName->chars, lst_size(block->data));
       lst_push_ptr(block->data, (void*)sub);


### PR DESCRIPTION
This happens in large alignments, such as in the Zoonomia alignments of 241 placental mammals.

There is a potential problem in allowing duplicate srcNames, if the srcName is also in a list of sequences to include/exclude, reorder, or mask, then this  might not be handled correctly. However, this problem also exists when just the species name component appears more than once, and is also in a list of sequences to include/exclude, reorder, or mask.